### PR TITLE
fix: add missing BaseModel import in settings.py

### DIFF
--- a/control-panel/backend/app/api/settings.py
+++ b/control-panel/backend/app/api/settings.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 
 from fastapi import APIRouter
+from pydantic import BaseModel
 from app.api.deps import CurrentUser, AdminUser
 from app.core.config import get_settings
 from app.core.database import get_session


### PR DESCRIPTION
## Fix for #96

**Root cause:** `NameError: name 'BaseModel' is not defined` at `app/api/settings.py:33` — missing `from pydantic import BaseModel`.

**Change:** Added the import on line 21.

**Verification:** Syntax check passes.

Fixes #96