### PR TITLE
fix: systematic import fix for settings.py (BaseModel, Depends, HTTPException, AsyncSession)

### DIFF
--- a/control-panel/backend/app/api/settings.py
+++ b/control-panel/backend/app/api/settings.py
@@ -6,10 +6,10 @@
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#
+
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#
+
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -18,7 +18,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.deps import CurrentUser, AdminUser
 from app.core.config import get_settings
 from app.core.database import get_session


### PR DESCRIPTION
## Resolves #96

### Problem
Pipeline **Validate Deployment** has been failing for **4+ days** (50/50 consecutive failures) at the `integration-tests` job. Root cause: missing imports in `app/api/settings.py`.

### Root Cause
PR #97 only added `from pydantic import BaseModel`, but the file also uses:
- `Depends` (from fastapi) — used on lines 64, 73
- `HTTPException` (from fastapi) — used on line 78
- `AsyncSession` (from sqlalchemy.ext.asyncio) — used on lines 64, 73

### Fix
Added all missing imports:
```python
from fastapi import APIRouter, Depends, HTTPException
from pydantic import BaseModel
from sqlalchemy.ext.asyncio import AsyncSession
```

### Impact
- **Severity:** P1 → P2 (pipeline completely blocked, including security fix PRs)
- **Consecutive failures:** 50 (0% success rate over last 50 runs)
- **Blocked PRs:** security/fix-nextjs-dos (CVSS 7.5), dependabot npm update
- **No production impact** (no active deploy)

### Testing
- Pipeline will re-run automatically on this PR
- The `unit-tests` and `config-validate` jobs were already passing; only `integration-tests` was failing due to this import error preventing container startup

cc: @clawdevsai