### PR TITLE
fix(governance): remove duplicate parameters and import causing SyntaxError

### DIFF
--- a/control-panel/backend/app/api/governance.py
+++ b/control-panel/backend/app/api/governance.py
@@ -34,7 +34,6 @@ from pydantic import BaseModel
 
 from app.api.deps import CurrentUser
 from app.core.database import get_session
-from app.api.deps import CurrentUser
 from app.services.governance_engine import GovernanceEngine
 from app.services.cost_tracker import CostTracker
 
@@ -251,7 +250,6 @@ async def check_budget(
     _: CurrentUser,
     tier: str = Query("medium", pattern="^(local|medium|premium)$"),
     session: AsyncSession = Depends(get_session),
-    tier: str = Query("medium", pattern="^(local|medium|premium)$"),
 ) -> dict:
     """
     Check if agent has budget available for task tier.
@@ -281,7 +279,6 @@ async def get_agent_spending(
     _: CurrentUser,
     days: int = Query(30, ge=1, le=365),
     session: AsyncSession = Depends(get_session),
-    days: int = Query(30, ge=1, le=365),
 ) -> dict:
     """
     Get agent's spending summary.
@@ -307,7 +304,6 @@ async def get_team_spending(
     _: CurrentUser,
     days: int = Query(30, ge=1, le=365),
     session: AsyncSession = Depends(get_session),
-    days: int = Query(30, ge=1, le=365),
 ) -> dict:
     """
     Get team-wide spending summary.

--- a/control-panel/backend/app/api/settings.py
+++ b/control-panel/backend/app/api/settings.py
@@ -6,10 +6,10 @@
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#
+
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-#
+
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -18,7 +18,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.deps import CurrentUser, AdminUser
 from app.core.config import get_settings
 from app.core.database import get_session


### PR DESCRIPTION
## Problem

The Validate Deployment pipeline has been failing (50/50 runs, 0% success rate) for 4+ days. Issue #96 tracked the original BaseModel import fix, but PR #101 still fails because a new SyntaxError was discovered:

```
File /app/app/api/governance.py, line 254
    tier: str = Query("medium", pattern="^(local|medium|premium)$"),
    ^^^^^^^
SyntaxError: duplicate argument tier in function definition
```

## Root Cause
Three functions in governance.py had duplicate parameter declarations:
1. check_budget() - tier defined twice (lines 253, 254)
2. get_agent_spending() - days defined twice
3. get_team_spending() - days defined twice

Plus a duplicate import of CurrentUser (line 32).

## Fix
- Remove duplicate tier parameter from check_budget()
- Remove duplicate days parameter from get_agent_spending()
- Remove duplicate days parameter from get_team_spending()
- Remove duplicate from app.api.deps import CurrentUser import

## Impact
- Unblocks the Validate Deployment pipeline (Issue #96)
- Unblocks security PRs #98, #100 (Next.js DoS CVSS 7.5)
- Unblocks dependabot PR #99

Closes #96